### PR TITLE
Preferable to have the httpd-configmap-generator pod startup upon deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $ cd httpd_configmap_generator
 $ docker build . -t manageiq/httpd_configmap_generator:latest
 ```
 
-### Running the httpd_configmap_generator container
+### Running the httpd\_configmap\_generator container
 
 
 ```
@@ -319,12 +319,6 @@ Deploy the Httpd Configmap Generator
 $ oc new-app --template=httpd-configmap-generator
 ```
 
-Scale up the Httpd Configmap Generator
-
-```
-$ oc scale dc httpd-configmap-generator --replicas=1
-```
-
 Check the readiness of the Httpd Configmap Generator
 
 ```
@@ -389,3 +383,9 @@ When done generating an auth-configmap, the httpd\_configmap\_generator pod can 
 $ oc scale dc httpd-configmap-generator --replicas=0
 ```
 
+or deleted if no longer needed:
+
+```
+$ oc delete all  -l app=httpd-configmap-generator
+$ oc delete pods -l app=httpd-configmap-generator
+```

--- a/templates/httpd-configmap-generator-template.yaml
+++ b/templates/httpd-configmap-generator-template.yaml
@@ -40,7 +40,7 @@ objects:
         timeoutSeconds: 1200
     triggers:
     - type: ConfigChange
-    replicas: 0
+    replicas: 1
     selector:
       name: "${HTTPD_CONFIGMAP_GENERATOR_SERVICE_NAME}"
     template:


### PR DESCRIPTION
It is preferable to have the httpd-configmap-generator start up upon deployment
so moving up the replicas to 1. If they didn't need it, they would not have deployed it.

Updated the template and related documentation.