### PR TITLE
Fixing support for Active Directory

### DIFF
--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -86,16 +86,10 @@ module HttpdConfigmapGenerator
       sssd.load(SSSD_CONFIG)
       sssd.configure_domain(domain)
       sssd.section("domain/#{domain}")["ad_server"] = opts[:ad_server] if opts[:ad_server].present?
-
       sssd.section("sssd")["domains"] = domain
       sssd.section("sssd")["default_domain_suffix"] = domain
-
       sssd.add_service("pam")
-      sssd.section("pam")["default_domain_suffix"] = domain
-
       sssd.configure_ifp
-      sssd.section("ifp")["default_domain_suffix"] = domain
-
       debug_msg("- Creating #{SSSD_CONFIG}")
       sssd.save(SSSD_CONFIG)
     end

--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -85,7 +85,7 @@ module HttpdConfigmapGenerator
       sssd = Sssd.new(opts)
       sssd.load(SSSD_CONFIG)
       sssd.configure_domain(domain)
-      sssd.section("domain")["ad_server"] = opts[:ad_server] if opts[:ad_server].present?
+      sssd.section("domain/#{domain}")["ad_server"] = opts[:ad_server] if opts[:ad_server].present?
 
       sssd.section("sssd")["domains"] = domain
       sssd.section("sssd")["default_domain_suffix"] = domain

--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -17,7 +17,8 @@ module HttpdConfigmapGenerator
 
     def optional_options
       super.merge(
-        :ad_realm => { :description => "Active Directory Realm" }
+        :ad_realm  => { :description => "Active Directory Realm"  },
+        :ad_server => { :description => "Active Directory Server" }
       )
     end
 
@@ -84,6 +85,8 @@ module HttpdConfigmapGenerator
       sssd = Sssd.new(opts)
       sssd.load(SSSD_CONFIG)
       sssd.configure_domain(domain)
+      sssd.section("domain")["ad_server"] = opts[:ad_server] if opts[:ad_server].present?
+
       sssd.section("sssd")["domain"] = domain
       sssd.section("sssd")["default_domain_suffix"] = domain
 

--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -79,6 +79,24 @@ module HttpdConfigmapGenerator
 
     private
 
+    def configure_sssd
+      info_msg("Configuring SSSD Service")
+      sssd = Sssd.new(opts)
+      sssd.load(SSSD_CONFIG)
+      sssd.configure_domain(domain)
+      sssd.section("sssd")["domain"] = domain
+      sssd.section("sssd")["default_domain_suffix"] = domain
+
+      sssd.add_service("pam")
+      sssd.section("pam")["default_domain_suffix"] = domain
+
+      sssd.configure_ifp
+      sssd.section("ifp")["default_domain_suffix"] = domain
+
+      debug_msg("- Creating #{SSSD_CONFIG}")
+      sssd.save(SSSD_CONFIG)
+    end
+
     def join_ad_realm
       info_msg("Joining the AD Realm ...")
       debug_msg(" - realm join #{realm} ...")

--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -87,7 +87,7 @@ module HttpdConfigmapGenerator
       sssd.configure_domain(domain)
       sssd.section("domain")["ad_server"] = opts[:ad_server] if opts[:ad_server].present?
 
-      sssd.section("sssd")["domain"] = domain
+      sssd.section("sssd")["domains"] = domain
       sssd.section("sssd")["default_domain_suffix"] = domain
 
       sssd.add_service("pam")

--- a/lib/httpd_configmap_generator/base.rb
+++ b/lib/httpd_configmap_generator/base.rb
@@ -81,16 +81,5 @@ module HttpdConfigmapGenerator
       output_file = Pathname.new(options[:output]).cleanpath.to_s
       raise "Output file must live under /tmp" unless output_file.start_with?("/tmp/")
     end
-
-    def configure_sssd
-      info_msg("Configuring SSSD Service")
-      sssd = Sssd.new(opts)
-      sssd.load(SSSD_CONFIG)
-      sssd.configure_domain(domain)
-      sssd.add_service("pam")
-      sssd.configure_ifp
-      debug_msg("- Creating #{SSSD_CONFIG}")
-      sssd.save(SSSD_CONFIG)
-    end
   end
 end

--- a/lib/httpd_configmap_generator/base/sssd.rb
+++ b/lib/httpd_configmap_generator/base/sssd.rb
@@ -41,8 +41,6 @@ module HttpdConfigmapGenerator
       ifp["user_attributes"] = LDAP_ATTRS.keys.collect { |k| "+#{k}" }.join(", ")
     end
 
-    private
-
     def section(key)
       if key =~ /^domain\/.*$/
         key = sssd.entries.collect(&:key).select { |k| k.downcase == key.downcase }.first

--- a/lib/httpd_configmap_generator/ipa.rb
+++ b/lib/httpd_configmap_generator/ipa.rb
@@ -97,6 +97,17 @@ module HttpdConfigmapGenerator
 
     private
 
+    def configure_sssd
+      info_msg("Configuring SSSD Service")
+      sssd = Sssd.new(opts)
+      sssd.load(SSSD_CONFIG)
+      sssd.configure_domain(domain)
+      sssd.add_service("pam")
+      sssd.configure_ifp
+      debug_msg("- Creating #{SSSD_CONFIG}")
+      sssd.save(SSSD_CONFIG)
+    end
+
     def configure_ipa_http_service
       info_msg("Configuring IPA HTTP Service")
       command_run!("/usr/bin/kinit", :params => [opts[:ipa_principal]], :stdin_data => opts[:ipa_password])


### PR DESCRIPTION

- implement AD specific configure_sssd method
- Moving the base configure_sssd to the ipa auth_type
- implement the --ad-server option and update sssd accordingly
