### PR TITLE
Removing restriction on -o output path.

### DIFF
--- a/lib/httpd_configmap_generator/base.rb
+++ b/lib/httpd_configmap_generator/base.rb
@@ -76,10 +76,8 @@ module HttpdConfigmapGenerator
       configure(opts)
     end
 
-    # NOTE: see if this can't be done by Trollop
-    def validate_options(options)
-      output_file = Pathname.new(options[:output]).cleanpath.to_s
-      raise "Output file must live under /tmp" unless output_file.start_with?("/tmp/")
+    def validate_options(_options)
+      nil
     end
   end
 end


### PR DESCRIPTION
Only allowed output to /tmp and limited the usage of the CLI.
