### PR TITLE
Removing miq references

### DIFF
--- a/README-saml.md
+++ b/README-saml.md
@@ -56,10 +56,10 @@ $ httpd_configmap_generator saml     \
 In the above example, the auth configmap file would include the following files:
 
 * /etc/httpd/saml2/
-  - miqsp-metadata.xml
-  - miqsp-cert.cert
-  - miqsp-key.key
+  - sp-metadata.xml
+  - sp-cert.cert
+  - sp-key.key
   - idp-metadata.xml
 
-For Keycloak, the `miqsp-metadata.xml` file can be imported to create the Client ID for
+For Keycloak, the `sp-metadata.xml` file can be imported to create the Client ID for
 the `application.example.com` application domain.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ $ httpd_configmap_generator update \
 ```
 $ httpd_configmap_generator update \
   --input=/tmp/original-auth-configmap.yaml \
-  --add-file=http://aab-keycloak:8080/auth/realms/miq/protocol/saml/description,/etc/httpd/saml2/idp-metadata.xml,644:root:root \
+  --add-file=http://aab-keycloak:8080/auth/realms/testrealm/protocol/saml/description,/etc/httpd/saml2/idp-metadata.xml,644:root:root \
   --output=/tmp/updated-auth-configmap.yaml
 ```
 
@@ -215,7 +215,7 @@ Example for generating a configuration map for IPA:
 
 ```
 $ docker exec $CONFIGMAP_GENERATOR_ID httpd_configmap_generator ipa \
-    --host=miq-appliance.example.com    \
+    --host=appliance.example.com        \
     --ipa-server=ipaserver.example.com  \
     --ipa-domain=example.com            \
     --ipa-realm=EXAMPLE.COM             \
@@ -262,18 +262,26 @@ ___
 
 #### If running without OCI systemd hooks (Minishift)
 
-The httpd-configmap-generator service account must be added to the miq-sysadmin SCC before the Httpd Auth Config pod can run.
+The httpd-configmap-generator service account must be added to the httpd-scc-sysadmin SCC before the Httpd Configmap Generator can run.
 
 ##### As Admin
 
-```
-$ oc adm policy add-scc-to-user miq-sysadmin system:serviceaccount:<your-namespace>:httpd-configmap-generator
-```
-
-Verify that the httpd-configmap-generator service account is now included in the miq-sysadmin SCC:
+Create the httpd-scc-sysadmin SCC:
 
 ```
-$ oc describe scc miq-sysadmin | grep Users
+$ oc create -f templates/httpd-scc-sysadmin.yaml
+```
+
+Include the httpd-configmap-generator service account with the new SCC:
+
+```
+$ oc adm policy add-scc-to-user httpd-scc-sysadmin system:serviceaccount:<your-namespace>:httpd-configmap-generator
+```
+
+Verify that the httpd-configmap-generator service account is now included in the httpd-scc-sysadmin SCC:
+
+```
+$ oc describe scc httpd-scc-sysadmin | grep Users
 Users:        system:serviceaccount:<your-namespace>:httpd-configmap-generator
 ```
 
@@ -285,7 +293,7 @@ Users:        system:serviceaccount:<your-namespace>:httpd-configmap-generator
 $ oc adm policy add-scc-to-user anyuid system:serviceaccount:<your-namespace>:httpd-configmap-generator
 ```
 
-Verify that the httpd-configmap-generator service account is now included in the miq-sysadmin SCC:
+Verify that the httpd-configmap-generator service account is included in the anyuid SCC:
 
 ```
 $ oc describe scc anyuid | grep Users
@@ -340,7 +348,7 @@ Example configuration:
 
 ```
 $ oc rsh $CONFIGMAP_GENERATOR_POD httpd_configmap_generator ipa \
-    --host=miq-appliance.example.com    \
+    --host=appliance.example.com        \
     --ipa-server=ipaserver.example.com  \
     --ipa-domain=example.com            \
     --ipa-realm=EXAMPLE.COM             \

--- a/lib/httpd_configmap_generator/saml.rb
+++ b/lib/httpd_configmap_generator/saml.rb
@@ -2,7 +2,7 @@ module HttpdConfigmapGenerator
   class Saml < Base
     MELLON_CREATE_METADATA_COMMAND = "/usr/libexec/mod_auth_mellon/mellon_create_metadata.sh".freeze
     SAML2_CONFIG_DIRECTORY = "/etc/httpd/saml2".freeze
-    MIQSP_METADATA_FILE    = "#{SAML2_CONFIG_DIRECTORY}/miqsp-metadata.xml".freeze
+    SP_METADATA_FILE       = "#{SAML2_CONFIG_DIRECTORY}/sp-metadata.xml".freeze
     IDP_METADATA_FILE      = "#{SAML2_CONFIG_DIRECTORY}/idp-metadata.xml".freeze
     AUTH = {
       :type    => "saml",
@@ -24,9 +24,9 @@ module HttpdConfigmapGenerator
 
     def persistent_files
       file_list = %w(
-        /etc/httpd/saml2/miqsp-key.key
-        /etc/httpd/saml2/miqsp-cert.cert
-        /etc/httpd/saml2/miqsp-metadata.xml
+        /etc/httpd/saml2/sp-key.key
+        /etc/httpd/saml2/sp-cert.cert
+        /etc/httpd/saml2/sp-metadata.xml
       )
       file_list += [IDP_METADATA_FILE] if opts[:keycloak_add_metadata]
       file_list
@@ -53,7 +53,7 @@ module HttpdConfigmapGenerator
     end
 
     def configured?
-      File.exist?(MIQSP_METADATA_FILE)
+      File.exist?(SP_METADATA_FILE)
     end
 
     def unconfigure
@@ -76,18 +76,18 @@ module HttpdConfigmapGenerator
       info_msg("Renaming mellon config files")
       Dir.chdir(SAML2_CONFIG_DIRECTORY) do
         Dir.glob("https_*.*") do |mellon_file|
-          miq_saml2_file = nil
+          saml2_file = nil
           case mellon_file
           when /^https_.*\.key$/
-            miq_saml2_file = "miqsp-key.key"
+            saml2_file = "sp-key.key"
           when /^https_.*\.cert$/
-            miq_saml2_file = "miqsp-cert.cert"
+            saml2_file = "sp-cert.cert"
           when /^https_.*\.xml$/
-            miq_saml2_file = "miqsp-metadata.xml"
+            saml2_file = "sp-metadata.xml"
           end
-          if miq_saml2_file
-            debug_msg("- renaming #{mellon_file} to #{miq_saml2_file}")
-            File.rename(mellon_file, miq_saml2_file)
+          if saml2_file
+            debug_msg("- renaming #{mellon_file} to #{saml2_file}")
+            File.rename(mellon_file, saml2_file)
           end
         end
       end

--- a/templates/httpd-scc-sysadmin.yaml
+++ b/templates/httpd-scc-sysadmin.yaml
@@ -1,0 +1,38 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+apiVersion: v1
+defaultAddCapabilities:
+- SYS_ADMIN
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: httpd-scc-sysadmin provides all features of the anyuid SCC but allows users to have SYS_ADMIN capabilities. This is the required scc for Pods requiring to run with systemd and the message bus.
+  creationTimestamp:
+  name: httpd-scc-sysadmin
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- SYS_CHROOT
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- secret


### PR DESCRIPTION
- SAML miqsp -> sp
- SAML miq-cookie -> sp-cookie
- using own httpd-scc-sysadmin instead of the miq-sysadmin SCC
- updating README.md to include usage/setup with httpd-scc-sysadmin

Depends on: https://github.com/ManageIQ/manageiq-pods/pull/240

Fixes #9 