### PR TITLE
Fix gemspec for CLI

### DIFF
--- a/httpd_configmap_generator.gemspec
+++ b/httpd_configmap_generator.gemspec
@@ -14,8 +14,10 @@ Gem::Specification.new do |s|
   s.description   = "The Httpd Configmap Generator"
   s.licenses      = ["Apache-2.0"]
 
-  s.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+  if Dir.exist?(File.join(__dir__, ".git"))
+    s.files = `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{^(test|spec|features)/})
+    end
   end
   s.bindir        = "bin"
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w(console setup)


### PR DESCRIPTION
When running the application via the gem installation, .git is not
present, but the Gemfile is used and tries to load the gemspec.  This
causes a warning when git is installed, and an error when git is not
installed.  Wrapping the files check prevents it from running except at
build time.

@abellotti Please review.