### PR TITLE
Convert host to canonical name when possible.

### DIFF
--- a/lib/httpd_configmap_generator/ipa.rb
+++ b/lib/httpd_configmap_generator/ipa.rb
@@ -1,3 +1,5 @@
+require "socket"               
+
 module HttpdConfigmapGenerator
   class Ipa < Base
     IPA_INSTALL_COMMAND  = "/usr/sbin/ipa-client-install".freeze
@@ -49,6 +51,7 @@ module HttpdConfigmapGenerator
     end
 
     def configure(opts)
+      opts[:host] = get_canonical_hostname(opts[:host])
       update_hostname(opts[:host])
       command_run!(IPA_INSTALL_COMMAND,
                    :params => [
@@ -117,6 +120,12 @@ module HttpdConfigmapGenerator
       command_run!(IPA_GETKEYTAB, :params => {"-s" => opts[:ipa_server], "-k" => HTTP_KEYTAB, "-p" => service.name})
       FileUtils.chown(APACHE_USER, nil, HTTP_KEYTAB)
       FileUtils.chmod(0o600, HTTP_KEYTAB)
+    end
+
+    def get_canonical_hostname(hostname)
+      Socket.gethostbyname(hostname)[0]
+    rescue SocketError
+      hostname
     end
   end
 end

--- a/spec/lib/httpd_configmap_generator/ipa_spec.rb
+++ b/spec/lib/httpd_configmap_generator/ipa_spec.rb
@@ -1,0 +1,42 @@
+require "httpd_configmap_generator/ipa"
+require "httpd_configmap_generator/base/config_map"
+
+describe HttpdConfigmapGenerator::Ipa do
+  describe "#configure" do
+    describe "#get_canonical_hostname" do
+      before do
+        @ipa = described_class.new()
+        allow(@ipa).to receive(:update_hostname)
+        allow(@ipa).to receive(:realm)
+        allow(@ipa).to receive(:domain)
+        allow(@ipa).to receive(:command_run!)
+        allow(@ipa).to receive(:configure_ipa_http_service)
+        allow(@ipa).to receive(:configure_pam)
+        allow(@ipa).to receive(:configure_sssd)
+        allow(@ipa).to receive(:enable_kerberos_dns_lookups)
+        allow(HttpdConfigmapGenerator::ConfigMap).to receive(:new).and_return(double(:generate => nil, :save => nil))
+      end
+
+      it "returns the canonical hostname when found" do
+        @initial_opts = {:host => "host-alias"}
+        expect(Socket).to receive(:gethostbyname).with("host-alias").and_return(["canonical-host"])
+        @ipa.configure(@initial_opts)
+        expect(@initial_opts[:host]).to eq("canonical-host")
+      end
+
+      it "returns the input hostname when it is the canonical hostname" do
+        @initial_opts = {:host => "canonical-host"}
+        expect(Socket).to receive(:gethostbyname).with("canonical-host").and_return(["canonical-host"])
+        @ipa.configure(@initial_opts)
+        expect(@initial_opts[:host]).to eq("canonical-host")
+      end
+
+      it "returns the input hostname when hostname is not found" do
+        @initial_opts = {:host => "host-name"}
+        expect(Socket).to receive(:gethostbyname).and_raise(SocketError)
+        @ipa.configure(@initial_opts)
+        expect(@initial_opts[:host]).to eq("host-name")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the hostname must be either the canonical hostname or not found in DNS.
This PR will add support allowing the hostname argument to a hostname alias (CNAME)

This is implemented using `Socket.gethostbyname`, which will  return the canonical name
or raise an error if the hostname is not found in DNS.

To test the added functionality confirm a valid configmap is generated for when a host alias (CNAME) is passed to the configmap generate.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1553790
