### PR TITLE
Remove /etc/sysconfig/network file from AD and Ldap auth types.

### DIFF
--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -37,7 +37,6 @@ module HttpdConfigmapGenerator
         /etc/resolv.conf
         /etc/sssd/sssd.conf
         /etc/sysconfig/authconfig
-        /etc/sysconfig/network
       )
     end
 

--- a/lib/httpd_configmap_generator/ipa.rb
+++ b/lib/httpd_configmap_generator/ipa.rb
@@ -46,7 +46,6 @@ module HttpdConfigmapGenerator
         /etc/pki/ca-trust/source/ipa.p11-kit
         /etc/sssd/sssd.conf
         /etc/sysconfig/authconfig
-        /etc/sysconfig/network
       )
     end
 

--- a/lib/httpd_configmap_generator/ipa.rb
+++ b/lib/httpd_configmap_generator/ipa.rb
@@ -46,6 +46,7 @@ module HttpdConfigmapGenerator
         /etc/pki/ca-trust/source/ipa.p11-kit
         /etc/sssd/sssd.conf
         /etc/sysconfig/authconfig
+        /etc/sysconfig/network
       )
     end
 

--- a/lib/httpd_configmap_generator/ldap.rb
+++ b/lib/httpd_configmap_generator/ldap.rb
@@ -55,8 +55,7 @@ module HttpdConfigmapGenerator
          /etc/pam.d/smartcard-auth-ac
          /etc/pam.d/system-auth-ac
          /etc/sssd/sssd.conf
-         /etc/sysconfig/authconfig
-         /etc/sysconfig/network) + [opts[:cert_file]]
+         /etc/sysconfig/authconfig) + [opts[:cert_file]]
     end
 
     def configure(opts)


### PR DESCRIPTION
Currently the config map generator erroneously include
the file /etc/sysconfig/network in the new config map.

This PR will prevent this file from being included in the new config map.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1579944