### PR TITLE
Remove the resolv.conf file and require the AD Server

### DIFF
--- a/lib/httpd_configmap_generator/active_directory.rb
+++ b/lib/httpd_configmap_generator/active_directory.rb
@@ -9,6 +9,7 @@ module HttpdConfigmapGenerator
 
     def required_options
       super.merge(
+        :ad_server   => { :description => "Active Directory Server"   },
         :ad_domain   => { :description => "Active Directory Domain"   },
         :ad_user     => { :description => "Active Directory User"     },
         :ad_password => { :description => "Active Directory Password" }
@@ -17,8 +18,7 @@ module HttpdConfigmapGenerator
 
     def optional_options
       super.merge(
-        :ad_realm  => { :description => "Active Directory Realm"  },
-        :ad_server => { :description => "Active Directory Server" }
+        :ad_realm  => { :description => "Active Directory Realm"  }
       )
     end
 
@@ -34,7 +34,6 @@ module HttpdConfigmapGenerator
         /etc/pam.d/postlogin-ac
         /etc/pam.d/smartcard-auth-ac
         /etc/pam.d/system-auth-ac
-        /etc/resolv.conf
         /etc/sssd/sssd.conf
         /etc/sysconfig/authconfig
       )


### PR DESCRIPTION
The resolv.conf file should not be included in the Active Directory config map.

Although we had always supplied it during testing, the ad_server
was coded to be an optional parameter. This PR ensures that it is
required.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1543638