### PR TITLE
Use Optimist

### DIFF
--- a/bin/httpd_configmap_generator
+++ b/bin/httpd_configmap_generator
@@ -8,7 +8,7 @@
 #
 
 Dir.chdir(__dir__) { require "bundler/setup" }
-require "trollop"
+require "optimist"
 require "httpd_configmap_generator"
 
 CMD = File.basename($PROGRAM_NAME)
@@ -23,7 +23,7 @@ module HttpdConfigmapGenerator
     SUB_COMMANDS = [HttpdConfigmapGenerator.supported_auth_types] | %w(update export)
 
     def run
-      Trollop.options do
+      Optimist.options do
         version("#{CMD} #{HttpdConfigmapGenerator::VERSION} - External Authentication Configuration script")
         banner <<-EOS
 #{version}
@@ -40,7 +40,7 @@ supported auth_type: #{HttpdConfigmapGenerator.supported_auth_types.join(', ')}
       end
 
       auth_type = ARGV.shift
-      Trollop.die "Must specify an authentication type" if auth_type.nil?
+      Optimist.die "Must specify an authentication type" if auth_type.nil?
 
       begin
         auth_config =
@@ -53,7 +53,7 @@ supported auth_type: #{HttpdConfigmapGenerator.supported_auth_types.join(', ')}
         error_msg(err.to_s)
       end
 
-      params = Trollop.options do
+      params = Optimist.options do
         auth_config.required_options.each do |key, key_options|
           opt key, key_options[:description], HttpdConfigmapGenerator::Cli.options_for(key_options, true)
         end

--- a/httpd_configmap_generator.gemspec
+++ b/httpd_configmap_generator.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.add_dependency "awesome_spawn",        "~> 1.4"
   s.add_dependency "iniparse",             "~> 1.4"
   s.add_dependency "more_core_extensions", "~> 3.4"
-  s.add_dependency "trollop",              "~> 2.1"
+  s.add_dependency "optimist",             "~> 3.0"
 end

--- a/spec/bin/httpd_configmap_generator_spec.rb
+++ b/spec/bin/httpd_configmap_generator_spec.rb
@@ -1,0 +1,21 @@
+describe "bin/httpd_configmap_generator" do
+  describe "--help" do
+    it "displays the expected info about the command" do
+      binfile   = File.expand_path("../../bin/httpd_configmap_generator", __dir__)
+      version   = HttpdConfigmapGenerator::VERSION
+      help_text = <<-HELP.gsub(/^ {8}/, "")
+        httpd_configmap_generator #{version} - External Authentication Configuration script
+
+        Usage: httpd_configmap_generator auth_type | update | export [--help | options]
+
+        supported auth_type: active-directory, ipa, ldap, saml, oidc
+
+        httpd_configmap_generator options are:
+          -V, --version    Version of the httpd_configmap_generator command
+          -h, --help       Show this message
+      HELP
+
+      expect(`#{binfile} --help`).to eq(help_text)
+    end
+  end
+end


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by `Optimist`.

Links
-----
* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)
* https://github.com/ManageIQ/manageiq/pull/18246