### PR TITLE
[Ruby 2.5] Sort the auth types so tests can predict the order

### DIFF
--- a/bin/httpd_configmap_generator
+++ b/bin/httpd_configmap_generator
@@ -30,7 +30,7 @@ module HttpdConfigmapGenerator
 
 Usage: #{CMD} auth_type | update | export [--help | options]
 
-supported auth_type: #{HttpdConfigmapGenerator.supported_auth_types.join(', ')}
+supported auth_type: #{HttpdConfigmapGenerator.supported_auth_types.sort.join(', ')}
 
 #{CMD} options are:
       EOS

--- a/spec/bin/httpd_configmap_generator_spec.rb
+++ b/spec/bin/httpd_configmap_generator_spec.rb
@@ -8,7 +8,7 @@ describe "bin/httpd_configmap_generator" do
 
         Usage: httpd_configmap_generator auth_type | update | export [--help | options]
 
-        supported auth_type: active-directory, ipa, ldap, saml, oidc
+        supported auth_type: active-directory, ipa, ldap, oidc, saml
 
         httpd_configmap_generator options are:
           -V, --version    Version of the httpd_configmap_generator command


### PR DESCRIPTION
The code walks constants to build the list of available auth types and
apparently this list is in a different sequence on ruby 2.5.

We can sort the types for the CLI's display so you can reliably test it.