### PR TITLE
Fix execution of the generator in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-Dockerfile.devel
 .rubocop-*
 /bundle/
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN dnf -y --disableplugin=subscription-manager install \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+RUN bundle config --global without development:test
 RUN gem install --no-document httpd_configmap_generator

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,101 @@
+PATH
+  remote: .
+  specs:
+    httpd_configmap_generator (0.3.1)
+      activesupport (>= 5.0)
+      awesome_spawn (~> 1.4)
+      iniparse (~> 1.4)
+      more_core_extensions (~> 3.4)
+      optimist (~> 3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    awesome_spawn (1.5.0)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
+    docile (1.4.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    iniparse (1.5.0)
+    manageiq-style (1.3.1)
+      more_core_extensions
+      optimist
+      rubocop (~> 1.13)
+      rubocop-performance
+      rubocop-rails
+    minitest (5.14.4)
+    more_core_extensions (3.8.0)
+      activesupport
+    optimist (3.0.1)
+    parallel (1.21.0)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    rake (13.0.6)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.22.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.12.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.12.0)
+      parser (>= 3.0.1.1)
+    rubocop-performance (1.11.5)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.12.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    ruby-progressbar (1.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.1.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-19
+
+DEPENDENCIES
+  httpd_configmap_generator!
+  manageiq-style
+  rake
+  rspec (~> 3.0)
+  simplecov
+
+BUNDLED WITH
+   2.2.24


### PR DESCRIPTION
In order to make bundler respect the Gemfile when we run the CLI, we
need to have both development and regular dependencies pre-resolved.
This is the point of the Gemfile.lock, so we need to commit it.  In the
Dockerfile we only install the gem, which only installs non-dev
dependencies, but bundler still needs the full resolution tree which is
in the Gemfile.lock.

Fixes #55

@jrafanie  Please review.