### PR TITLE
Add authselect-compat to restore authconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV HTTPD_AUTH_TYPE=internal \
 RUN dnf -y --disableplugin=subscription-manager install \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf -y --disableplugin=subscription-manager install \
+        authselect-compat \
         openldap-clients \
         pamtester && \
     dnf clean all && \


### PR DESCRIPTION
authconfig is no longer available in RHEL8, so use authselect-compat
instead as it provides a compatibility layer.

Fixes #56

@jrafanie or @bdunne Please review.