### PR TITLE
Add manageiq user to allowed_uids for sssd

### DIFF
--- a/lib/httpd_configmap_generator/base/sssd.rb
+++ b/lib/httpd_configmap_generator/base/sssd.rb
@@ -37,7 +37,7 @@ module HttpdConfigmapGenerator
     def configure_ifp
       add_service("ifp")
       ifp = section("ifp")
-      ifp["allowed_uids"] = "#{APACHE_USER}, root"
+      ifp["allowed_uids"] = "#{APACHE_USER}, root, manageiq"
       ifp["user_attributes"] = LDAP_ATTRS.keys.collect { |k| "+#{k}" }.join(", ")
     end
 


### PR DESCRIPTION
When we moved to using a manageiq user, we need to add this user so it has permission in sssd.conf.

See also:
https://github.com/ManageIQ/manageiq/pull/22715
https://github.com/ManageIQ/manageiq-documentation/pull/1743 https://github.com/ManageIQ/manageiq-appliance_console/pull/220